### PR TITLE
fix: crop crash confirm button always disabled

### DIFF
--- a/src/vue-core-image-upload.vue
+++ b/src/vue-core-image-upload.vue
@@ -234,9 +234,9 @@
       },
 
       __setUpload(btn) {
-        btn.value = btn.value + '...';
-        btn.disabled = true;
         const upload = (code) => {
+          btn.value = btn.value + '...';
+          btn.disabled = true;
           this.tryAjaxUpload(() => {
             btn.value = btn.value.replace('...','');
             btn.disabled = false;


### PR DESCRIPTION
修复裁剪图片如果发生错误，确定按钮一直保持禁用状态的问题。